### PR TITLE
Always-allowed words can be specified for crosswordValidQ

### DIFF
--- a/src/crosswordValidQ.js
+++ b/src/crosswordValidQ.js
@@ -76,7 +76,7 @@ function isSingleGroupingQ(grid) {
   return numLetters === connectedIndexes.length;
 }
 
-export function crosswordValidQ({ grid, trie }) {
+export function crosswordValidQ({ grid, trie, exceptedWords = [] }) {
   const isSingleGrouping = isSingleGroupingQ(grid);
   if (!isSingleGrouping) {
     return {
@@ -110,7 +110,13 @@ export function crosswordValidQ({ grid, trie }) {
           !character.match("^[A-Z]$"))
       ) {
         if (currentWord.length > 1) {
-          const { isWord } = isKnown(currentWord, trie);
+          // If the word is one of the excepted words, always consider it valid.
+          // Otherwise, check whether it is a word in the trie.
+          let isWord = exceptedWords.includes(currentWord);
+          if (!isWord) {
+            ({ isWord } = isKnown(currentWord, trie));
+          }
+
           if (!isWord) {
             return {
               gameIsSolved: false,


### PR DESCRIPTION
Adds an `exceptedWords` list input to crosswordValidQ. If a word in the crossword is on that list, the word is always considered a known word even if it isn't in the trie.

The `exceptedWords` input defaults to an empty list, so games that rely on the `crosswordValidQ` function should continue to work without any updates.

The purpose of this is to enable proper validation of puzzles that were generated with a word that was later deemed 'uncommon' in @skedwards88/word_lists (as described in https://github.com/skedwards88/crossjig/pull/22).

Tests are added in https://github.com/skedwards88/word_logic/pull/3