### PR TITLE
Update some functions to accept non-square dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skedwards88/word_logic",
-  "version": "2.0.7",
+  "version": "3.0.0",
   "description": "A collection of word-related functions.",
   "main": "index.js",
   "scripts": {

--- a/src/checkIfNeighbors.js
+++ b/src/checkIfNeighbors.js
@@ -1,9 +1,9 @@
 import { getSurroundingIndexes } from "./getSurroundingIndexes.js";
 
-export function checkIfNeighbors({ indexA, indexB, gridSize }) {
+export function checkIfNeighbors({ indexA, indexB, numColumns, numRows }) {
   // Check if two indexes are neighbors in a grid
-  // given the two indexes and the grid size
-  // If only one index is provided, returns true
+  // given the two indexes and the grid dimensions.
+  // If only one index is provided, returns true.
 
   if (indexA === undefined || indexB === undefined) {
     return true;
@@ -11,7 +11,8 @@ export function checkIfNeighbors({ indexA, indexB, gridSize }) {
 
   const surroundingIndexes = getSurroundingIndexes({
     index: indexB,
-    gridSize: gridSize,
+    numColumns,
+    numRows,
   });
 
   return surroundingIndexes.includes(indexA) ? true : false;

--- a/src/checkIfNeighbors.test.js
+++ b/src/checkIfNeighbors.test.js
@@ -1,23 +1,23 @@
 import { checkIfNeighbors } from "./checkIfNeighbors";
 
 test("Zero is considered a value", () => {
-  expect(checkIfNeighbors({ indexA: 0, indexB: 5, gridSize: 4 })).toEqual(true);
+  expect(checkIfNeighbors({ indexA: 0, indexB: 5, numColumns: 4, numRows: 7 })).toEqual(true);
 });
 
 test("Not neighbors", () => {
-  expect(checkIfNeighbors({ indexA: 0, indexB: 4, gridSize: 5 })).toEqual(
+  expect(checkIfNeighbors({ indexA: 0, indexB: 4, numColumns: 5, numRows: 5 })).toEqual(
     false
   );
 });
 
 test("True if either index undefined", () => {
   expect(
-    checkIfNeighbors({ indexA: undefined, indexB: 5, gridSize: 4 })
+    checkIfNeighbors({ indexA: undefined, indexB: 5, numColumns: 4, numRows: 7 })
   ).toEqual(true);
   expect(
-    checkIfNeighbors({ indexA: undefined, indexB: undefined, gridSize: 4 })
+    checkIfNeighbors({ indexA: undefined, indexB: undefined, numColumns: 4, numRows: 7 })
   ).toEqual(true);
   expect(
-    checkIfNeighbors({ indexA: 6, indexB: undefined, gridSize: 4 })
+    checkIfNeighbors({ indexA: 6, indexB: undefined, numColumns: 4, numRows: 7 })
   ).toEqual(true);
 });

--- a/src/findAllWords.js
+++ b/src/findAllWords.js
@@ -2,16 +2,18 @@ import { getSurroundingIndexes } from "./getSurroundingIndexes.js";
 import { isKnown } from "./isKnown.js";
 
 export function findAllWordIndexes({
-  grid,
+  letters,
+  numColumns,
+  numRows,
   minWordLength,
   maxWordLength = 30,
   easyMode,
-  trie
+  trie,
 }) {
   let foundWordIndexes = [];
 
-  const neighborIndexes = grid.map((_, index) =>
-    getSurroundingIndexes({ index: index, gridSize: Math.sqrt(grid.length) })
+  const neighborIndexes = letters.map((_, index) =>
+    getSurroundingIndexes({ index: index, numColumns, numRows })
   );
 
   function checkSurrounding(currentIndex, wordIndexes, visitedIndexes) {
@@ -22,7 +24,7 @@ export function findAllWordIndexes({
         continue;
       }
       const newWordIndexes = [...wordIndexes, surroundingIndex];
-      const newWord = newWordIndexes.map((index) => grid[index]).join("");
+      const newWord = newWordIndexes.map((index) => letters[index]).join("");
       const { isPartial, isWord, isEasy } = isKnown(newWord, trie);
 
       if (easyMode) {
@@ -52,7 +54,7 @@ export function findAllWordIndexes({
     }
   }
 
-  for (let startingIndex = 0; startingIndex < grid.length; startingIndex++) {
+  for (let startingIndex = 0; startingIndex < letters.length; startingIndex++) {
     checkSurrounding(startingIndex, [startingIndex], [startingIndex]);
   }
 
@@ -60,21 +62,25 @@ export function findAllWordIndexes({
 }
 
 export function findAllWords({
-  grid,
+  letters,
+  numColumns,
+  numRows,
   minWordLength,
   maxWordLength = 30,
   easyMode,
   trie,
 }) {
   const foundWordIndexes = findAllWordIndexes({
-    grid: grid,
+    letters: letters,
+    numColumns: numColumns,
+    numRows: numRows,
     minWordLength: minWordLength,
     maxWordLength: maxWordLength,
     easyMode: easyMode,
     trie: trie,
   });
   const foundWords = foundWordIndexes.map((indexList) =>
-    indexList.map((index) => grid[index]).join("")
+    indexList.map((index) => letters[index]).join("")
   );
   const uniqueFoundWords = new Set(foundWords);
 

--- a/src/findAllWords.test.js
+++ b/src/findAllWords.test.js
@@ -14,8 +14,8 @@ const uncommonWords = [
 ];
 const trie = getTrie(commonWords, uncommonWords);
 
-test("Easy mode, min length 4", () => {
-  const grid = [
+test("Easy mode, min length 4, square grid", () => {
+  const letters = [
     "O",
     "C",
     "QU",
@@ -34,7 +34,9 @@ test("Easy mode, min length 4", () => {
     "K",
   ];
   const foundWords = findAllWords({
-    grid: grid,
+    letters: letters,
+    numColumns: Math.sqrt(letters.length),
+    numRows: Math.sqrt(letters.length),
     minWordLength: 4,
     easyMode: true,
     trie: trie,
@@ -45,8 +47,8 @@ test("Easy mode, min length 4", () => {
   expect(foundWords.length).toEqual(expected.length);
 });
 
-test("Hard mode, min length 4", () => {
-  const grid = [
+test("Hard mode, min length 4, square grid", () => {
+  const letters = [
     "O",
     "C",
     "QU",
@@ -65,7 +67,9 @@ test("Hard mode, min length 4", () => {
     "K",
   ];
   const foundWords = findAllWords({
-    grid: grid,
+    letters: letters,
+    numColumns: Math.sqrt(letters.length),
+    numRows: Math.sqrt(letters.length),
     minWordLength: 4,
     easyMode: false,
     trie: trie,
@@ -77,8 +81,8 @@ test("Hard mode, min length 4", () => {
   expect(foundWords.length).toEqual(expected.length);
 });
 
-test("Easy mode, min length 3", () => {
-  const grid = [
+test("Easy mode, min length 3, square grid", () => {
+  const letters = [
     "O",
     "C",
     "QU",
@@ -97,7 +101,9 @@ test("Easy mode, min length 3", () => {
     "K",
   ];
   const foundWords = findAllWords({
-    grid: grid,
+    letters: letters,
+    numColumns: Math.sqrt(letters.length),
+    numRows: Math.sqrt(letters.length),
     minWordLength: 3,
     easyMode: true,
     trie: trie,
@@ -109,8 +115,8 @@ test("Easy mode, min length 3", () => {
   expect(foundWords.length).toEqual(expected.length);
 });
 
-test("Hard mode, min length 3", () => {
-  const grid = [
+test("Hard mode, min length 3, square grid", () => {
+  const letters = [
     "O",
     "C",
     "QU",
@@ -129,13 +135,58 @@ test("Hard mode, min length 3", () => {
     "K",
   ];
   const foundWords = findAllWords({
-    grid: grid,
+    letters: letters,
+    numColumns: Math.sqrt(letters.length),
+    numRows: Math.sqrt(letters.length),
     minWordLength: 3,
     easyMode: false,
     trie: trie,
   });
 
   const expected = ["CAMP", "QUIET", "CAMPER", "SCAMPER", "LET"];
+
+  expect(foundWords).toEqual(expect.arrayContaining(expected));
+  expect(foundWords.length).toEqual(expected.length);
+});
+
+test("Easy mode, min length 4, wider grid", () => {
+  const letters = [
+    "O","C","QU","I","W",
+    "S","A","E","T","A",
+    "P","M","L","T","L",
+    "P","E","R","K","K",
+  ];
+  const foundWords = findAllWords({
+    letters: letters,
+    numColumns: 5,
+    numRows: 4,
+    minWordLength: 4,
+    easyMode: true,
+    trie: trie,
+  });
+  const expected = ["CAMP", "QUIET", "WALK"];
+
+  expect(foundWords).toEqual(expect.arrayContaining(expected));
+  expect(foundWords.length).toEqual(expected.length);
+});
+
+test("Easy mode, min length 4, taller grid", () => {
+  const letters = [
+    "O","C","QU","I",
+    "S","A","E","T",
+    "P","M","L","T",
+    "P","E","R","K",
+    "W","A","L","K"
+  ];
+  const foundWords = findAllWords({
+    letters: letters,
+    numColumns: 4,
+    numRows: 5,
+    minWordLength: 4,
+    easyMode: true,
+    trie: trie,
+  });
+  const expected = ["CAMP", "QUIET", "WALK"];
 
   expect(foundWords).toEqual(expect.arrayContaining(expected));
   expect(foundWords.length).toEqual(expected.length);

--- a/src/getSurroundingIndexes.js
+++ b/src/getSurroundingIndexes.js
@@ -1,6 +1,6 @@
-export function getSurroundingIndexes({ index, gridSize }) {
-  const column = index % gridSize;
-  const row = Math.floor(index / gridSize);
+export function getSurroundingIndexes({ index, numColumns, numRows }) {
+  const column = index % numColumns;
+  const row = Math.floor(index / numColumns);
   let surroundingIndexes = [];
   for (let currentRow = row - 1; currentRow <= row + 1; currentRow++) {
     for (
@@ -11,10 +11,10 @@ export function getSurroundingIndexes({ index, gridSize }) {
       if (
         currentRow >= 0 &&
         currentColumn >= 0 &&
-        currentRow < gridSize &&
-        currentColumn < gridSize
+        currentRow < numRows &&
+        currentColumn < numColumns
       ) {
-        const currentIndex = currentColumn + currentRow * gridSize;
+        const currentIndex = currentColumn + currentRow * numColumns;
         surroundingIndexes.push(currentIndex);
       }
     }

--- a/src/getSurroundingIndexes.test.js
+++ b/src/getSurroundingIndexes.test.js
@@ -1,7 +1,7 @@
 import { getSurroundingIndexes } from "./getSurroundingIndexes";
 
 test("top left corner", () => {
-  const surrounding = getSurroundingIndexes({ index: 0, gridSize: 5 });
+  const surrounding = getSurroundingIndexes({ index: 0, numColumns: 5, numRows: 17 });
   const expected = [0, 1, 5, 6];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
@@ -9,7 +9,7 @@ test("top left corner", () => {
 });
 
 test("top right corner", () => {
-  const surrounding = getSurroundingIndexes({ index: 3, gridSize: 4 });
+  const surrounding = getSurroundingIndexes({ index: 3, numColumns: 4, numRows: 14 });
   const expected = [2, 3, 6, 7];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
@@ -17,7 +17,7 @@ test("top right corner", () => {
 });
 
 test("top middle", () => {
-  const surrounding = getSurroundingIndexes({ index: 2, gridSize: 4 });
+  const surrounding = getSurroundingIndexes({ index: 2, numColumns: 4, numRows: 31 });
   const expected = [1, 2, 3, 5, 6, 7];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
@@ -25,7 +25,7 @@ test("top middle", () => {
 });
 
 test("left middle", () => {
-  const surrounding = getSurroundingIndexes({ index: 10, gridSize: 5 });
+  const surrounding = getSurroundingIndexes({ index: 10, numColumns: 5, numRows: 17 });
   const expected = [5, 6, 10, 11, 16, 15];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
@@ -33,7 +33,7 @@ test("left middle", () => {
 });
 
 test("center", () => {
-  const surrounding = getSurroundingIndexes({ index: 12, gridSize: 5 });
+  const surrounding = getSurroundingIndexes({ index: 12, numColumns: 5, numRows: 7 });
   const expected = [6, 7, 8, 11, 12, 13, 16, 17, 18];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
@@ -41,15 +41,23 @@ test("center", () => {
 });
 
 test("bottom left corner", () => {
-  const surrounding = getSurroundingIndexes({ index: 12, gridSize: 4 });
+  const surrounding = getSurroundingIndexes({ index: 12, numColumns: 4, numRows: 4 });
   const expected = [8, 9, 12, 13];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));
   expect(surrounding.length).toEqual(expected.length);
 });
 
+test("bottom middle", () => {
+  const surrounding = getSurroundingIndexes({ index: 13, numColumns: 3, numRows: 5 });
+  const expected = [9,10,11,12,13,14];
+
+  expect(surrounding).toEqual(expect.arrayContaining(expected));
+  expect(surrounding.length).toEqual(expected.length);
+});
+
 test("bottom right corner", () => {
-  const surrounding = getSurroundingIndexes({ index: 24, gridSize: 5 });
+  const surrounding = getSurroundingIndexes({ index: 24, numColumns: 5, numRows: 5 });
   const expected = [18, 19, 23, 24];
 
   expect(surrounding).toEqual(expect.arrayContaining(expected));


### PR DESCRIPTION
Updates the following functions:

- checkIfNeighbors
- findAllWords
- findAllWordIndexes
- getSurroundingIndexes

These functions now accept parameters for the number of rows and columns, instead of assuming that the grid of interest is square.

This is a breaking change.