### PR TITLE
Specify the empty value for centerGrid and GetMaxShifts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skedwards88/word_logic",
-  "version": "3.0.8",
+  "version": "4.0.0",
   "description": "A collection of word-related functions.",
   "main": "index.js",
   "type": "module",

--- a/src/centerGrid.js
+++ b/src/centerGrid.js
@@ -2,15 +2,17 @@ import cloneDeep from "lodash.clonedeep";
 import {getMaxShifts} from "./getMaxShifts.js";
 import {transposeGrid} from "./transposeGrid.js";
 
-export function centerGrid(grid) {
+export function centerGrid(grid, emptyValue) {
   let shiftedGrid = cloneDeep(grid);
 
-  const emptyRow = Array(grid.length).fill("");
+  const emptyRow = Array(grid.length).fill(emptyValue);
 
   // determine the number of current empty edge rows
   // and the number of empty edge rows when centered
-  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} =
-    getMaxShifts(grid);
+  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} = getMaxShifts(
+    grid,
+    emptyValue,
+  );
   const averageShiftLeftRight = (maxShiftLeft + maxShiftRight) / 2;
   const newMaxShiftLeft = Math.floor(averageShiftLeftRight);
   const newMaxShiftRight = Math.ceil(averageShiftLeftRight);

--- a/src/centerGrid.test.js
+++ b/src/centerGrid.test.js
@@ -9,7 +9,7 @@ test("Centers a 2D grid of letters", () => {
     ["F", "B", "", "", ""],
   ];
 
-  const centeredGrid = centerGrid(grid);
+  const centeredGrid = centerGrid(grid, "");
 
   const expectedGrid = [
     ["", "", "", "", ""],
@@ -17,6 +17,51 @@ test("Centers a 2D grid of letters", () => {
     ["", "E", "", "C", ""],
     ["", "F", "B", "", ""],
     ["", "", "", "", ""],
+  ];
+
+  expect(centeredGrid).toEqual(expectedGrid);
+});
+
+test("Centers a 2D grid where the empty values are 0 instead of an empty string", () => {
+  const grid = [
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 1, 0, 0, 0],
+    [1, 0, 1, 0, 0],
+    [1, 1, 0, 0, 0],
+  ];
+
+  const centeredGrid = centerGrid(grid, 0);
+
+  const expectedGrid = [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 1, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ];
+
+  expect(centeredGrid).toEqual(expectedGrid);
+});
+
+test("Centers a 2D grid where the empty values are undefined instead of an empty string", () => {
+  const grid = [
+    [undefined, undefined, undefined, undefined, undefined],
+    [undefined, undefined, undefined, undefined, undefined],
+    [undefined, "DOG", undefined, undefined, undefined],
+    ["ELK", undefined, "COW", undefined, undefined],
+    ["FISH", "BIRD", undefined, undefined, undefined],
+  ];
+
+  const centeredGrid = centerGrid(grid, undefined);
+
+  console.log(centeredGrid);
+  const expectedGrid = [
+    [undefined, undefined, undefined, undefined, undefined],
+    [undefined, undefined, "DOG", undefined, undefined],
+    [undefined, "ELK", undefined, "COW", undefined],
+    [undefined, "FISH", "BIRD", undefined, undefined],
+    [undefined, undefined, undefined, undefined, undefined],
   ];
 
   expect(centeredGrid).toEqual(expectedGrid);
@@ -41,7 +86,7 @@ test("If the grid can't be perfectly centered, errs towards the top left", () =>
     ["", "D", "", "", "", ""],
   ];
 
-  expect(centerGrid(gridBottomLeft)).toEqual(expectedGrid);
+  expect(centerGrid(gridBottomLeft, "")).toEqual(expectedGrid);
 
   const gridBottomRight = [
     ["", "", "", "", "", ""],
@@ -52,7 +97,7 @@ test("If the grid can't be perfectly centered, errs towards the top left", () =>
     ["", "", "", "", "D", ""],
   ];
 
-  expect(centerGrid(gridBottomRight)).toEqual(expectedGrid);
+  expect(centerGrid(gridBottomRight, "")).toEqual(expectedGrid);
 
   const gridTopLeft = [
     ["", "B", "", "", "", ""],
@@ -63,7 +108,7 @@ test("If the grid can't be perfectly centered, errs towards the top left", () =>
     ["", "", "", "", "", ""],
   ];
 
-  expect(centerGrid(gridTopLeft)).toEqual(expectedGrid);
+  expect(centerGrid(gridTopLeft, "")).toEqual(expectedGrid);
 
   const gridTopRight = [
     ["", "", "", "", "B", ""],
@@ -74,7 +119,7 @@ test("If the grid can't be perfectly centered, errs towards the top left", () =>
     ["", "", "", "", "", ""],
   ];
 
-  expect(centerGrid(gridTopRight)).toEqual(expectedGrid);
+  expect(centerGrid(gridTopRight, "")).toEqual(expectedGrid);
 });
 
 test("If the grid is already centered up/down, will still center right/left", () => {
@@ -86,7 +131,7 @@ test("If the grid is already centered up/down, will still center right/left", ()
     ["", "", "", "", ""],
   ];
 
-  const centeredGrid = centerGrid(grid);
+  const centeredGrid = centerGrid(grid, "");
 
   const expectedGrid = [
     ["", "", "", "", ""],
@@ -108,7 +153,7 @@ test("If the grid is already centered right/left, will still center up/down", ()
     ["", "F", "B", "", ""],
   ];
 
-  const centeredGrid = centerGrid(grid);
+  const centeredGrid = centerGrid(grid, "");
 
   const expectedGrid = [
     ["", "", "", "", ""],
@@ -131,7 +176,7 @@ test("Errors if the grid is not a square", () => {
     ["A", "", "C", "", ""],
   ];
 
-  expect(() => centerGrid(grid)).toThrow(
+  expect(() => centerGrid(grid, "")).toThrow(
     "The number of columns and number of rows in the grid must be equal.",
   );
 });

--- a/src/getMaxShifts.js
+++ b/src/getMaxShifts.js
@@ -1,12 +1,12 @@
 import {transposeGrid} from "./transposeGrid.js";
 
 // get the number of empty rows/columns on each side of a 2D grid
-export function getMaxShifts(grid) {
+export function getMaxShifts(grid, emptyValue) {
   const transposedGrid = transposeGrid(grid);
 
   let maxShiftUp = 0;
   for (let index = 0; index < grid.length; index++) {
-    if (grid[index].every((i) => i === "")) {
+    if (grid[index].every((i) => i == emptyValue)) {
       maxShiftUp++;
     } else {
       break;
@@ -15,7 +15,7 @@ export function getMaxShifts(grid) {
 
   let maxShiftDown = 0;
   for (let index = grid.length - 1; index >= 0; index--) {
-    if (grid[index].every((i) => i === "")) {
+    if (grid[index].every((i) => i == emptyValue)) {
       maxShiftDown++;
     } else {
       break;
@@ -24,7 +24,7 @@ export function getMaxShifts(grid) {
 
   let maxShiftLeft = 0;
   for (let index = 0; index < transposedGrid.length; index++) {
-    if (transposedGrid[index].every((i) => i === "")) {
+    if (transposedGrid[index].every((i) => i == emptyValue)) {
       maxShiftLeft++;
     } else {
       break;
@@ -33,7 +33,7 @@ export function getMaxShifts(grid) {
 
   let maxShiftRight = 0;
   for (let index = transposedGrid.length - 1; index >= 0; index--) {
-    if (transposedGrid[index].every((i) => i === "")) {
+    if (transposedGrid[index].every((i) => i == emptyValue)) {
       maxShiftRight++;
     } else {
       break;

--- a/src/getMaxShifts.test.js
+++ b/src/getMaxShifts.test.js
@@ -10,8 +10,52 @@ test("Gets the number of empty rows/columns on each side of a 2D grid", () => {
     ["", "A", "", "C", "", ""],
   ];
 
-  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} =
-    getMaxShifts(grid);
+  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} = getMaxShifts(
+    grid,
+    "",
+  );
+
+  expect(maxShiftLeft).toEqual(1);
+  expect(maxShiftRight).toEqual(2);
+  expect(maxShiftUp).toEqual(1);
+  expect(maxShiftDown).toEqual(0);
+});
+
+test("Gets the number of empty rows/columns on each side of a 2D grid where the empty values are 0", () => {
+  const grid = [
+    [0, 0, 0, 0, 0, 0],
+    [0, 1, 0, 1, 0, 0],
+    [0, 1, 1, 1, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+    [0, 1, 1, 1, 0, 0],
+    [0, 1, 0, 1, 0, 0],
+  ];
+
+  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} = getMaxShifts(
+    grid,
+    0,
+  );
+
+  expect(maxShiftLeft).toEqual(1);
+  expect(maxShiftRight).toEqual(2);
+  expect(maxShiftUp).toEqual(1);
+  expect(maxShiftDown).toEqual(0);
+});
+
+test("Gets the number of empty rows/columns on each side of a 2D grid where the empty values are undefined", () => {
+  const grid = [
+    [undefined, undefined, undefined, undefined, undefined, undefined],
+    [undefined, "ANT", undefined, "CROW", undefined, undefined],
+    [undefined, "ART", "BALLOON", "CAR", undefined, undefined],
+    [undefined, undefined, undefined, undefined, undefined, undefined],
+    [undefined, "AWL", "ZIP", "CAT", undefined, undefined],
+    [undefined, "ARF", undefined, "COw", undefined, undefined],
+  ];
+
+  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} = getMaxShifts(
+    grid,
+    undefined,
+  );
 
   expect(maxShiftLeft).toEqual(1);
   expect(maxShiftRight).toEqual(2);
@@ -28,8 +72,10 @@ test("Returns 0 in all directions if grid can't be shifted", () => {
     ["A", "", "C", "", ""],
   ];
 
-  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} =
-    getMaxShifts(grid);
+  const {maxShiftLeft, maxShiftRight, maxShiftUp, maxShiftDown} = getMaxShifts(
+    grid,
+    "",
+  );
 
   expect(maxShiftLeft).toEqual(0);
   expect(maxShiftRight).toEqual(0);
@@ -47,7 +93,7 @@ test("Errors if the grid is not a square", () => {
     ["A", "", "C", "", ""],
   ];
 
-  expect(() => getMaxShifts(grid)).toThrow(
+  expect(() => getMaxShifts(grid, "")).toThrow(
     "The number of columns and number of rows in the grid must be equal.",
   );
 });


### PR DESCRIPTION
Adds an emptyValue argument for the centerGrid and getMaxShift functions instead of defaulting to an empty string. Because defaulting the new emptyValue argument to an empty string would preclude a value of undefined for the argument, the default value is undefined instead. Because this is a breaking change, bumps the major version number.